### PR TITLE
Add pandoc build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build Book
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive texlive-xetex
+
+      - name: Compile book
+        run: ./scripts/build.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: libro
+          path: |
+            dist/Liberando_al_Robot.pdf
+            dist/Liberando_al_Robot.epub

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p dist
+files=(
+  chapters/00_prologo.md
+  chapters/01_introduccion.md
+  chapters/02_muerte_de_la_idea_lineal.md
+  chapters/03_ingenieria_inversa_de_la_colaboracion.md
+  chapters/04_llms_como_infraestructura.md
+  chapters/05_pensar_como_red.md
+  chapters/06_el_rol_de_la_cultura.md
+  chapters/07_frameworks_y_protocolos.md
+  chapters/08_experimentos_abiertos.md
+  chapters/09_manifesto_final.md
+)
+
+pandoc "${files[@]}" --toc --pdf-engine=xelatex -o dist/Liberando_al_Robot.pdf
+pandoc "${files[@]}" --toc -o dist/Liberando_al_Robot.epub


### PR DESCRIPTION
## Summary
- add script to compile PDF and EPUB
- automate build of book using GitHub Actions

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y pandoc texlive texlive-xetex`
- `./scripts/build.sh`

------
https://chatgpt.com/codex/tasks/task_b_684493d319688322af315328157a472c