### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,50 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive texlive-xetex
+
+      - name: Compile book
+        run: ./scripts/build.sh
+
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p public
+          cp dist/Liberando_al_Robot.html public/index.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- deploy `Liberando_al_Robot.html` on pushes to `main`

## Testing
- `./scripts/build.sh` *(fails: `pandoc: command not found` before install)*
- `sudo apt-get update`
- `sudo apt-get install -y pandoc texlive texlive-xetex`
- `./scripts/build.sh`

------
https://chatgpt.com/codex/tasks/task_b_68449a2a3420832286fa9ec342598f03