### PR TITLE
Add CITATION file and link in README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: "If you use this book, please cite it as follows."
+title: "Liberando al Robot"
+authors:
+  - family-names: Mercado
+    given-names: Raúl
+preferred-citation:
+  type: book
+  title: "Liberando al Robot"
+  authors:
+    - family-names: Mercado
+      given-names: Raúl
+  year: 2024

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Este libro está siendo desarrollado por [Raúl Mercado](https://www.linkedin.co
 ## 📎 Enlaces clave
 
 - [Sitio de lectura colaborativa](https://lnkd.in/eSFDs5xk)  
-- [Miro/mapa conceptual (si aplica)](https://example.com)  
+- [Miro/mapa conceptual (si aplica)](https://example.com)
 - [Documento fundacional/tagline/sinopsis](libro_tagline_sinopsis.md)
+- [Cómo citar este libro](CITATION.cff)
 
 ---
 


### PR DESCRIPTION
## Summary
- add a CITATION.cff with Raúl Mercado listed as author
- link CITATION file from README key links section

## Testing
- `bash scripts/build.sh` *(fails: `pandoc` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68449b92426c8322876f120ec65c0c2d