### PR TITLE
Add lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint Markdown
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli
+
+      - name: Run markdownlint
+        run: markdownlint '**/*.md'
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install codespell
+        run: pip install codespell
+
+      - name: Run codespell
+        run: codespell -q 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,14 @@ Gracias por querer mejorar **Liberando al Robot**. Sigue estos pasos para colabo
 ## Discusión de cambios
 
 Para ideas grandes o dudas, abre un *issue*. Los Pull Requests también son bienvenidos para conversar ajustes específicos.
+
+## Comprobaciones locales
+
+Antes de enviar tu PR puedes verificar el estado de los archivos `.md` con estas herramientas:
+
+1. Instala las dependencias:
+   - `npm install -g markdownlint-cli`
+   - `pip install codespell`
+2. Ejecuta:
+   - `markdownlint '**/*.md'` para revisar estilo Markdown.
+   - `codespell` para encontrar errores ortográficos.


### PR DESCRIPTION
## Summary
- run markdownlint and codespell on PRs
- explain how to run these tools locally

## Testing
- `npm install -g markdownlint-cli`
- `markdownlint '**/*.md'` *(fails: line length issues)*
- `pip install codespell`
- `codespell -q 3` *(fails: found spelling mistakes)*

------
https://chatgpt.com/codex/tasks/task_b_68449c4ad410832295413094f72823ce