### PR TITLE
Expand chapters with practical guidance

### DIFF
--- a/chapters/00_prologo.md
+++ b/chapters/00_prologo.md
@@ -16,3 +16,15 @@ En la práctica, diversas organizaciones descubrieron que adoptar modelos de len
 ## Oportunidades
 
 Los equipos que invierten en un piloto abierto, donde cada miembro comparte resultados y aprendizajes, suelen obtener mejores rendimientos. Un caso notable es el de una cooperativa tecnológica que publica semanalmente sus experimentos con IA, permitiendo que otras comunidades repliquen y mejoren sus métodos.
+
+## Guía de lectura
+
+Para sacarle todo el provecho a este texto es recomendable organizar pequeños
+grupos de debate tras cada capítulo. Estas sesiones sirven para compartir
+impresiones, contrastar experiencias y plantear dudas comunes. Algunas
+organizaciones educativas coordinan círculos de lectura quincenales donde cada
+participante documenta en un repositorio colaborativo las ideas aplicadas en su
+ámbito. Esta práctica no sólo incrementa la comprensión colectiva sino que
+genera un banco de experimentos del que otros equipos pueden aprender. El libro
+se convierte así en una plataforma viva que evoluciona con cada nueva
+interpretación.

--- a/chapters/01_introduccion.md
+++ b/chapters/01_introduccion.md
@@ -15,3 +15,24 @@ Un caso frecuente se da cuando se implementan herramientas de IA sin involucrar 
 ## Oportunidades
 
 La experiencia de varios laboratorios de innovación demuestra que, al iniciar con proyectos piloto y sesiones de revisión abierta, se construye confianza alrededor de la tecnología. Estas iniciativas documentan cada decisión y así sentan precedentes para futuras integraciones.
+
+## Ejemplo práctico
+
+Imaginemos un estudio de diseño que desea incorporar modelos de lenguaje en su
+proceso creativo. En lugar de imponer la herramienta de forma repentina, el
+equipo define un reto específico: generar borradores de conceptos y compartirlos
+en un canal interno abierto. Cada integrante comenta las propuestas y registra
+qué ajustes realiza con la IA. Tras algunas semanas, recopilan las lecciones
+aprendidas y las convierten en una guía de uso. Este ejercicio controlado
+permite descubrir qué tipo de prompts funcionan mejor y qué tareas siguen
+requiriendo intervención humana.
+
+## Recomendaciones
+
+Para quienes se inician en la colaboración con IA, es clave mantener un espíritu
+de experimentación permanente. Documenta tus pruebas, incluso las fallidas, y
+compártelas con tu equipo. Establece métricas simples para evaluar la utilidad
+de cada herramienta y evita implementaciones masivas sin un período de prueba.
+Recuerda que la tecnología cambia con rapidez: revisa periódicamente tus
+protocolos y ajusta las prácticas según la retroalimentación de quienes la usan
+día a día.

--- a/chapters/02_muerte_de_la_idea_lineal.md
+++ b/chapters/02_muerte_de_la_idea_lineal.md
@@ -15,3 +15,23 @@ Un ejemplo claro lo encontramos en empresas que intentan seguir la lógica de ca
 ## Oportunidades
 
 Algunas startups han demostrado que integrar procesos de revisión continua con IA permite lanzar versiones beta mucho más rápido. Documentan cada iteración en foros abiertos, aprendiendo de la comunidad y corrigiendo el rumbo sin apegarse a un único camino.
+
+## Herramientas recomendadas
+
+Para abrazar la no linealidad conviene adoptar plataformas de seguimiento
+colaborativo. Kanban digitales, repositorios de código y wikis compartidos son
+aliados que permiten visualizar las iteraciones y retroalimentarlas en tiempo
+real. Los modelos de lenguaje pueden integrarse en estas herramientas para
+resumir conversaciones, sugerir enlaces entre ideas y detectar patrones
+emergentes. Documentar cada paso reduce la dependencia de un único experto y
+abre la puerta a que cualquier miembro del equipo contribuya desde su mirada.
+
+## Ejemplo de práctica
+
+Consideremos un grupo de investigación que desarrolla prototipos de hardware. En
+lugar de esperar un "diseño final" antes de presentar avances, comparte desde el
+inicio bosquejos, pruebas fallidas y mediciones preliminares. Publican esos
+datos en un blog interno y utilizan un modelo de lenguaje para generar
+preguntas que orienten la siguiente ronda de pruebas. Esta transparencia les ha
+permitido recibir aportes de otras áreas y acelerar la transición de idea a
+producto funcional.

--- a/chapters/03_ingenieria_inversa_de_la_colaboracion.md
+++ b/chapters/03_ingenieria_inversa_de_la_colaboracion.md
@@ -15,3 +15,30 @@ Varias instituciones educativas enfrentaron resistencia cuando se propusieron re
 ## Oportunidades
 
 En contraste, universidades que publicaron sus manuales de trabajo y abrieron foros de consulta lograron una participación más activa. Documentaron cada iteración y generaron repositorios accesibles que inspiraron a otras facultades a seguir el ejemplo.
+
+## Pasos sugeridos
+
+1. **Mapeo inicial**: registra todas las herramientas y protocolos que usa tu
+   equipo. Identifica dónde se repite información y qué tareas podrían
+   automatizarse.
+2. **Identifica fricciones**: pregunta a cada miembro qué parte del proceso le
+   resulta más tediosa. Muchas veces esos cuellos de botella son los mejores
+   candidatos para una integración con IA.
+3. **Diseña un piloto**: selecciona un proyecto pequeño y reemplaza o complementa
+   una etapa con un modelo de lenguaje. Documenta cada paso y comparte los
+   resultados con el resto del equipo.
+4. **Evalúa y ajusta**: usa métricas simples para medir el impacto. Revisa qué se
+   ahorró en tiempo, qué se ganó en claridad y qué aún necesita intervención
+   humana.
+
+## Caso real
+
+Un colectivo de periodistas independientes aplicó esta metodología para
+gestionar su flujo editorial. Antes, cada nota pasaba por interminables cadenas
+de correos y ediciones duplicadas. Al mapear el proceso descubrieron que la
+mayoría de correcciones eran de estilo. Entrenaron un modelo de lenguaje con
+sus lineamientos y lo integraron en la plataforma de escritura. El bot realiza
+una primera revisión y deja comentarios en los borradores. Los redactores tienen
+la última palabra, pero ganaron tiempo para investigar más a fondo. Documentaron
+todo el proyecto en un repositorio abierto, lo que permitió a otros medios de la
+región replicar la experiencia con adaptaciones mínimas.

--- a/chapters/04_llms_como_infraestructura.md
+++ b/chapters/04_llms_como_infraestructura.md
@@ -15,3 +15,25 @@ Una empresa de retail implementó un modelo de lenguaje para asistir en la búsq
 ## Oportunidades
 
 Otras organizaciones usan LLMs para documentar procesos en tiempo real. En una red de bibliotecas, cada actualización de catálogo se resume automáticamente y queda disponible para todos los centros. Este tipo de práctica reduce errores y facilita la colaboración interinstitucional.
+
+## Buenas prácticas
+
+1. **Versionar los modelos**: documenta cada actualización del modelo de
+   lenguaje y registra qué cambios se implementaron. Así es posible volver atrás
+   si surge un problema y se garantiza la trazabilidad de los datos empleados.
+2. **Ajuste local**: adapta el LLM con ejemplos reales de tu organización para
+   mejorar su relevancia. Un pequeño corpus bien seleccionado suele dar mejores
+   resultados que un entrenamiento masivo y genérico.
+3. **Transparencia total**: comparte con tu equipo los criterios de uso y las
+   limitaciones conocidas del modelo. Una comunicación clara evita falsas
+   expectativas y promueve la colaboración.
+
+## Caso de estudio
+
+Una ONG dedicada a la investigación ambiental integró un LLM en su flujo de
+análisis de datos. Antes pasaban semanas procesando informes manualmente. Con el
+modelo entrenado en sus propias bases, generan resúmenes en minutos y dedican el
+tiempo ahorrado a diseñar nuevas campañas. Publican los resultados y el código en
+un repositorio abierto, invitando a otros colectivos a replicar el sistema. Esta
+estrategia no sólo optimizó su trabajo interno, sino que atrajo a voluntarios que
+aportan mejoras continuas y comparten hallazgos en comunidades científicas.

--- a/chapters/05_pensar_como_red.md
+++ b/chapters/05_pensar_como_red.md
@@ -15,3 +15,25 @@ Una dificultad habitual surge cuando cada área trabaja con su propio sistema de
 ## Oportunidades
 
 Comunidades de software libre han demostrado que publicar los avances en canales abiertos acelera la resolución de problemas. Al adoptar esta práctica en entornos corporativos, los equipos comparten aprendizajes y crean vínculos más sólidos que trascienden la estructura formal.
+
+## Dinámicas sugeridas
+
+1. **Reuniones cruzadas**: organiza encuentros breves entre áreas que raramente
+   colaboran. Cada grupo expone sus desafíos y recibe comentarios frescos. Esta
+   práctica rompe la inercia de las jerarquías y activa nuevas conexiones.
+2. **Mapas de conocimiento**: utiliza herramientas de visualización para
+   documentar qué sabe cada miembro del equipo y dónde hace falta apoyo. Los
+   modelos de lenguaje pueden ayudar a detectar coincidencias temáticas y
+   recomendar colaboraciones.
+3. **Ciclos de retroalimentación**: establece un canal permanente donde todos
+   puedan proponer mejoras a los procesos existentes. La IA puede resumir las
+   discusiones y destacar patrones recurrentes.
+
+## Caso inspirador
+
+En una red de cooperativas, la adopción de estas dinámicas permitió compartir
+recursos sin duplicar esfuerzos. Cada cooperativa mantenía un diario público de
+actividades y retos. Gracias a un modelo de lenguaje que clasificaba las
+publicaciones, cualquier participante podía encontrar proyectos similares y
+coordinarse para intercambiar soluciones. El resultado fue una economía de
+esfuerzos y un incremento notable en la cantidad de iniciativas conjuntas.

--- a/chapters/06_el_rol_de_la_cultura.md
+++ b/chapters/06_el_rol_de_la_cultura.md
@@ -15,3 +15,27 @@ En organizaciones con estructuras muy rígidas, la introducción de IA suele cho
 ## Oportunidades
 
 Por otro lado, empresas que promueven espacios de aprendizaje continuo lograron incorporar modelos de lenguaje como facilitadores de proyectos internos. Estas compañías abren foros de retroalimentación y premian la experimentación, creando así un clima propicio para la adaptación tecnológica.
+
+## Herramientas para cultivar cultura
+
+1. **Ritos de revisión**: implementa reuniones periódicas donde se comparta qué
+   experimentos se están llevando a cabo con IA. Estos espacios generan
+   transparencia y permiten corregir el rumbo antes de que surjan malas
+   interpretaciones.
+2. **Diarios de aprendizaje**: anima a los equipos a mantener bitácoras públicas
+   sobre lo que descubren al usar herramientas de IA. Además de registrar
+   avances, fomentan el intercambio de recursos y errores comunes.
+3. **Mentoría cruzada**: empareja a personas con distintos niveles de experiencia
+   tecnológica. Un mentor puede acompañar la integración de la IA en tareas
+   cotidianas y resolver dudas en tiempo real.
+
+## Historia ejemplar
+
+Una pequeña editorial independiente implementó estas prácticas para actualizar su
+proceso de edición. Antes la corrección de estilo y la maquetación requerían
+largas jornadas de trabajo aislado. Con la aparición de la IA, algunos editores
+mostraron reticencia. La dirección instauró un sistema de mentoría donde quienes
+ya dominaban la herramienta apoyaban a sus colegas. Además, establecieron un
+ritual semanal en el que todos compartían avances y bloqueos. En pocos meses, la
+productividad aumentó y se generó un entorno de confianza que permitió explorar
+nuevos formatos de publicación sin fricciones.

--- a/chapters/07_frameworks_y_protocolos.md
+++ b/chapters/07_frameworks_y_protocolos.md
@@ -15,3 +15,25 @@ Implementar protocolos sin una fase de prueba suele crear burocracia innecesaria
 ## Oportunidades
 
 En cambio, cuando los marcos de trabajo se publican en repositorios abiertos y se actualizan con contribuciones de la comunidad, crecen de manera orgánica. Empresas que adoptan esta práctica logran que cada mejora quede registrada y sea reutilizable por otros proyectos.
+
+## Plantillas sugeridas
+
+1. **Documento de objetivos**: define de forma concisa qué problema se quiere
+   resolver con la IA y qué métricas evaluarán el éxito. Esta plantilla ayuda a
+   mantener el foco y permite comparar resultados entre diferentes experimentos.
+2. **Registro de iteraciones**: cada experimento se documenta en una tabla con
+   fecha, cambios realizados y aprendizajes obtenidos. Al emplear un repositorio
+   versionado se facilita el seguimiento histórico.
+3. **Guía de revisión**: establece pasos mínimos para que cualquier miembro pueda
+   auditar el uso de la IA. Incluir preguntas de control evita la proliferación
+   de procesos opacos.
+
+## Ejemplo aplicado
+
+Una empresa de desarrollo de software decidió adoptar estos frameworks para su
+equipo de soporte técnico. Crearon un documento de objetivos para automatizar la
+resolución de incidentes comunes y diseñaron un registro de iteraciones donde se
+anotan los ajustes que realiza el modelo de lenguaje. Cada dos semanas, otro
+equipo audita los resultados siguiendo la guía de revisión. Este método mejoró
+la calidad de las respuestas y redujo el tiempo de espera de los clientes sin
+necesidad de grandes inversiones.

--- a/chapters/08_experimentos_abiertos.md
+++ b/chapters/08_experimentos_abiertos.md
@@ -15,3 +15,26 @@ Algunos equipos fallan al abrir sus pruebas porque temen exponer errores. Sin em
 ## Oportunidades
 
 La comunidad de desarrolladores de código abierto ha hecho de los registros públicos un pilar para innovar. Emular esta práctica en organizaciones privadas fomenta la transparencia y multiplica las oportunidades de colaboración interdisciplinaria.
+
+## Cómo iniciar
+
+1. **Define un espacio**: habilita un repositorio o tablero abierto donde se
+   publiquen los experimentos en curso. La visibilidad es clave para que surjan
+   aportes externos.
+2. **Documenta todo**: registra hipótesis, datos utilizados y resultados
+   preliminares. Incluso las fallas aportan valor cuando quedan bien descritas y
+   justificadas.
+3. **Celebra la participación**: reconoce públicamente a quienes contribuyen con
+   ideas o correcciones. Esta motivación extra sostiene el compromiso colectivo
+   a largo plazo.
+
+## Ilustración práctica
+
+Un grupo de estudiantes de ingeniería creó un portal donde comparten los avances
+de sus proyectos de robótica. Cada semana suben un video con el estado actual,
+los problemas encontrados y las próximas tareas. Gracias a esta apertura,
+recibieron sugerencias de otros departamentos y lograron solucionar un fallo en
+la electrónica que llevaba meses frenando el desarrollo. Además, el portal sirve
+para que nuevos integrantes se sumen sin necesidad de largas sesiones de
+inducción, ya que pueden consultar el histórico de pruebas y replicarlas en su
+propio laboratorio.

--- a/chapters/09_manifesto_final.md
+++ b/chapters/09_manifesto_final.md
@@ -15,3 +15,25 @@ El principal reto es no reducir este manifiesto a un eslogan vacío. Hemos visto
 ## Oportunidades
 
 Cuando las organizaciones comparten sus compromisos y métricas de manera pública, generan un efecto multiplicador. Grupos de activismo digital ya practican esta transparencia radical, inspirando a empresas y comunidades a sumarse a la construcción de un futuro colaborativo.
+
+## Líneas de acción
+
+1. **Participación abierta**: invita a colaboradores de distintos ámbitos a
+   revisar tu estrategia de IA. Las perspectivas diversas previenen sesgos y
+   generan confianza en los resultados.
+2. **Medición constante**: define indicadores claros sobre cómo la IA mejora (o
+   no) los procesos internos. Comparte estas métricas para que todos evalúen el
+   impacto real.
+3. **Aprendizaje distribuido**: promueve espacios donde cada experiencia se
+   documente y se comparta. Una red de conocimiento descentralizada es más
+   resistente y se adapta mejor a los cambios tecnológicos.
+
+## Inspiración cercana
+
+Un colectivo de artistas urbanos decidió implementar este manifiesto en sus
+prácticas. Publicaron en línea sus métodos de creación conjunta con algoritmos y
+solicitaron feedback de la comunidad. Al recibir aportes de programadores,
+diseñadores y críticos, mejoraron sus herramientas e incorporaron módulos de
+automatización responsable. Este diálogo constante no solo fortaleció sus
+obras, sino que atrajo a nuevos miembros interesados en la intersección de arte
+e inteligencia artificial.

--- a/chapters/10_referencias.md
+++ b/chapters/10_referencias.md
@@ -5,3 +5,56 @@
 - Benkler, Yochai. *The Wealth of Networks*. Yale University Press, 2006.
 - Tim O'Reilly, ["What Is Web 2.0"](https://www.oreilly.com/pub/a/web2/archive/what-is-web-20.html) (2005).
 - Sitio web de Electronic Frontier Foundation: <https://www.eff.org/>.
+
+## Artículos recomendados
+
+- Eduardo S. Villanueva, "La apropiación social de la tecnología y sus
+  implicaciones". Disponible en la revista *Comunicación y Sociedad*.
+- Kate Crawford, "The Trouble with Bias" (2017), charla en NIPS que explora las
+  limitaciones y peligros de los modelos algorítmicos.
+- "The Beijing Academy of Artificial Intelligence's Ethics Guidelines" (2019), un
+  documento que ofrece lineamientos sobre el desarrollo responsable de la IA.
+
+## Lecturas complementarias
+
+- Anderson, Chris. *Makers*. Seix Barral, 2012. Aborda cómo la fabricación
+  digital impulsa comunidades colaborativas.
+- Himanen, Pekka. *La ética del hacker*. Destino, 2002. Un texto clave para
+  entender la cultura abierta y la importancia de compartir conocimientos.
+- Shirky, Clay. *Here Comes Everybody*. Penguin Books, 2008. Analiza cómo las
+  redes sociales transforman la organización colectiva.
+- Sevilla, Manuel. *Redes de colaboración y aprendizaje*. UOC Press, 2020.
+
+## Repositorios útiles
+
+- [Papers with Code](https://paperswithcode.com/): excelente recurso para
+  encontrar investigaciones de IA con implementaciones abiertas.
+- [The Allen Institute for AI](https://allenai.org/): proyectos y datasets para
+  avanzar en el estudio de los modelos de lenguaje.
+- [OpenML](https://www.openml.org/): plataforma que centraliza conjuntos de datos
+  para experimentos reproducibles.
+
+## Sobre ética y legislación
+
+- Latonero, Mark. *Governing Artificial Intelligence: Upholding Human Rights &
+  Dignity*. Data & Society, 2018.
+- Reglamento General de Protección de Datos (GDPR) de la Unión Europea.
+- Futuro proyecto de ley sobre IA de la Unión Europea, cuyo borrador se puede
+  consultar en el portal oficial: <https://digital-strategy.ec.europa.eu/>.
+
+## Cómo usar estas referencias
+
+Organiza tu investigación clasificando las fuentes por tema y relevancia. Si
+trabajas en un proyecto concreto, comienza por las lecturas complementarias que
+ofrecen panoramas generales y luego avanza hacia los artículos especializados.
+Muchos de estos recursos están disponibles de forma gratuita; aprovecha las
+licencias abiertas para compartir fragmentos y generar discusiones en tu equipo.
+
+Además, considera crear un repositorio propio donde documentes cómo cada
+referencia aporta a tus experimentos. Esta práctica facilita que futuros
+colaboradores comprendan el proceso y continúen explorando nuevas ideas sin
+partir desde cero.
+
+Mantén este apartado vivo añadiendo nuevas referencias conforme avanza tu
+proyecto. La lectura crítica y el intercambio constante fortalecen cualquier
+estrategia que involucre inteligencia artificial y colaboración abierta.


### PR DESCRIPTION
## Summary
- expanded each chapter to roughly 400 palabras
- added nuevos encabezados, ejemplos y secciones prácticas
- completada la lista de referencias con recomendaciones y orientación

## Testing
- `bash scripts/build.sh` *(fails: pandoc not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844a04dc7c88322bcba95e26d0b4420