### PR TITLE
Add repository URL and DOI to citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,8 @@ title: "Liberando al Robot"
 authors:
   - family-names: Mercado
     given-names: Raúl
+doi: 10.0000/placeholder-doi
+repository-code: https://github.com/Rolphs/Liberando-al-robot
 preferred-citation:
   type: book
   title: "Liberando al Robot"


### PR DESCRIPTION
## Summary
- provide repository-code URL for Liberando-al-robot
- add placeholder DOI in citation file

## Testing
- `cffconvert --validate --infile CITATION.cff`

------
https://chatgpt.com/codex/tasks/task_b_6844a346e74c8322b1e3a684f13922f4