### PR TITLE
Add codespell dictionary and workflow fix

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,3 +1,5 @@
 manifiesto
 posible
 sinopsis
+autor
+serie

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,5 @@ jobs:
         run: pip install codespell
 
       - name: Run codespell
-        run: codespell -q 3 --ignore-words .codespellignore
+        run: |
+          codespell -q 3 --ignore-words .codespellignore


### PR DESCRIPTION
## Summary
- extend `.codespellignore` with extra Spanish words
- update lint workflow step for codespell

## Testing
- `markdownlint '**/*.md'`
- `codespell -q 3 --ignore-words .codespellignore`


------
https://chatgpt.com/codex/tasks/task_b_6844dfc609148322ab03bc085b2d9866