### PR TITLE
Add apt caching in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install pandoc
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/build.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-
+
+      - name: Install Pandoc and LaTeX
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc texlive texlive-xetex
+          sudo apt-get install -y --no-install-recommends pandoc texlive-latex-recommended texlive-xetex
 
-      - name: Compile book
+      - name: Build book
         run: ./scripts/build.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: libro
-          path: |
-            dist/Liberando_al_Robot.pdf
-            dist/Liberando_al_Robot.epub
-            dist/Liberando_al_Robot.html
+          path: dist/


### PR DESCRIPTION
## Summary
- install Pandoc/LaTeX with cached apt packages
- run build script and upload `dist/` outputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6844e170c43c83228586a4c134942727