### PR TITLE
Add crosslinks to synopsis

### DIFF
--- a/chapters/00_prologo.md
+++ b/chapters/00_prologo.md
@@ -28,3 +28,5 @@ participante documenta en un repositorio colaborativo las ideas aplicadas en su
 genera un banco de experimentos del que otros equipos pueden aprender. El libro
 se convierte así en una plataforma viva que evoluciona con cada nueva
 interpretación.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/01_introduccion.md
+++ b/chapters/01_introduccion.md
@@ -36,3 +36,5 @@ de cada herramienta y evita implementaciones masivas sin un período de prueba.
 Recuerda que la tecnología cambia con rapidez: revisa periódicamente tus
 protocolos y ajusta las prácticas según la retroalimentación de quienes la usan
 día a día.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/02_muerte_de_la_idea_lineal.md
+++ b/chapters/02_muerte_de_la_idea_lineal.md
@@ -35,3 +35,5 @@ datos en un blog interno y utilizan un modelo de lenguaje para generar
 preguntas que orienten la siguiente ronda de pruebas. Esta transparencia les ha
 permitido recibir aportes de otras áreas y acelerar la transición de idea a
 producto funcional.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/03_ingenieria_inversa_de_la_colaboracion.md
+++ b/chapters/03_ingenieria_inversa_de_la_colaboracion.md
@@ -42,3 +42,5 @@ una primera revisión y deja comentarios en los borradores. Los redactores tiene
 la última palabra, pero ganaron tiempo para investigar más a fondo. Documentaron
 todo el proyecto en un repositorio abierto, lo que permitió a otros medios de la
 región replicar la experiencia con adaptaciones mínimas.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/04_llms_como_infraestructura.md
+++ b/chapters/04_llms_como_infraestructura.md
@@ -37,3 +37,5 @@ tiempo ahorrado a diseñar nuevas campañas. Publican los resultados y el códig
 un repositorio abierto, invitando a otros colectivos a replicar el sistema. Esta
 estrategia no sólo optimizó su trabajo interno, sino que atrajo a voluntarios que
 aportan mejoras continuas y comparten hallazgos en comunidades científicas.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/05_pensar_como_red.md
+++ b/chapters/05_pensar_como_red.md
@@ -37,3 +37,5 @@ actividades y retos. Gracias a un modelo de lenguaje que clasificaba las
 publicaciones, cualquier participante podía encontrar proyectos similares y
 coordinarse para intercambiar soluciones. El resultado fue una economía de
 esfuerzos y un incremento notable en la cantidad de iniciativas conjuntas.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)


### PR DESCRIPTION
## Summary
- link from README to tagline
- link early chapters to tagline for easier navigation

## Testing
- `markdownlint README.md chapters/*.md libro_tagline_sinopsis.md`
- `codespell -q 3 --ignore-words .codespellignore README.md chapters/*.md libro_tagline_sinopsis.md`


------
https://chatgpt.com/codex/tasks/task_b_6844e236709c8322902f35968dea6ab8