### PR TITLE
Append tagline link to later chapters

### DIFF
--- a/chapters/06_el_rol_de_la_cultura.md
+++ b/chapters/06_el_rol_de_la_cultura.md
@@ -39,3 +39,5 @@ ya dominaban la herramienta apoyaban a sus colegas. Además, establecieron un
 ritual semanal en el que todos compartían avances y bloqueos. En pocos meses, la
 productividad aumentó y se generó un entorno de confianza que permitió explorar
 nuevos formatos de publicación sin fricciones.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/07_frameworks_y_protocolos.md
+++ b/chapters/07_frameworks_y_protocolos.md
@@ -37,3 +37,5 @@ anotan los ajustes que realiza el modelo de lenguaje. Cada dos semanas, otro
 equipo audita los resultados siguiendo la guía de revisión. Este método mejoró
 la calidad de las respuestas y redujo el tiempo de espera de los clientes sin
 necesidad de grandes inversiones.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/08_experimentos_abiertos.md
+++ b/chapters/08_experimentos_abiertos.md
@@ -38,3 +38,5 @@ la electrónica que llevaba meses frenando el desarrollo. Además, el portal sir
 para que nuevos integrantes se sumen sin necesidad de largas sesiones de
 inducción, ya que pueden consultar el histórico de pruebas y replicarlas en su
 propio laboratorio.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/09_manifesto_final.md
+++ b/chapters/09_manifesto_final.md
@@ -37,3 +37,5 @@ diseñadores y críticos, mejoraron sus herramientas e incorporaron módulos de
 automatización responsable. Este diálogo constante no solo fortaleció sus
 obras, sino que atrajo a nuevos miembros interesados en la intersección de arte
 e inteligencia artificial.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/10_referencias.md
+++ b/chapters/10_referencias.md
@@ -66,3 +66,5 @@ partir desde cero.
 Mantén este apartado vivo añadiendo nuevas referencias conforme avanza tu
 proyecto. La lectura crítica y el intercambio constante fortalecen cualquier
 estrategia que involucre inteligencia artificial y colaboración abierta.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)

--- a/chapters/11_glosario.md
+++ b/chapters/11_glosario.md
@@ -12,3 +12,5 @@ Este glosario reúne conceptos técnicos y estratégicos utilizados a lo largo d
 - **Pensar como red:** Perspectiva que prioriza las conexiones entre personas y máquinas para construir conocimiento distribuido.
 - **Retroalimentación:** Información que permite evaluar y refinar un proyecto o decisión estratégica.
 - **Transparencia:** Principio de exponer métodos y datos de forma clara para fortalecer la confianza dentro de la comunidad.
+
+[Lee la sinopsis y el tagline del libro](../libro_tagline_sinopsis.md)


### PR DESCRIPTION
## Summary
- append tagline link to the remaining chapters

## Testing
- `./scripts/build.sh` *(fails: pandoc not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846105808e88322ba65d987e2ef0a5f