### PR TITLE
Add glossary chapter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Lo desarrollamos en este repositorio aplicando los mismos principios que predica
 - [08_experimentos_abiertos](chapters/08_experimentos_abiertos.md)
 - [09_manifesto_final](chapters/09_manifesto_final.md)
 - [10_referencias](chapters/10_referencias.md)
+- [11_glosario](chapters/11_glosario.md)
 
 Cada capítulo está diseñado para:
 


### PR DESCRIPTION
## Summary
- add chapter 11 link under the structure section of the README

## Testing
- `bash scripts/build.sh` *(fails: pandoc not found)*

------
https://chatgpt.com/codex/tasks/task_b_684612788db483229efdad85a98c6f06