### PR TITLE
Add check script for Markdown and spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,6 @@ Antes de enviar tu PR puedes verificar el estado de los archivos `.md` con estas
 1. Instala las dependencias:
    - `npm install -g markdownlint-cli`
    - `pip install codespell`
-2. Ejecuta:
+2. Ejecuta `./scripts/check.sh` para correr ambas herramientas o usa los comandos individuales:
    - `markdownlint '**/*.md'` para revisar estilo Markdown.
-   - `codespell` para encontrar errores ortográficos.
+   - `codespell -q 3 --ignore-words .codespellignore` para encontrar errores ortográficos.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+markdownlint '**/*.md'
+codespell -q 3 --ignore-words .codespellignore


### PR DESCRIPTION
## Summary
- add a `scripts/check.sh` helper for markdownlint and codespell
- mention the script in `CONTRIBUTING.md`

## Testing
- `./scripts/check.sh > /tmp/check.log 2>&1 || true`
- `tail -n 20 /tmp/check.log`

------
https://chatgpt.com/codex/tasks/task_b_68461ea5c158832285c371c0228b7a41